### PR TITLE
+ support for SQLite, PostgreSQL and MariaDB via sqlx

### DIFF
--- a/sqlxdb/mariadb.go
+++ b/sqlxdb/mariadb.go
@@ -7,19 +7,30 @@ import (
 
 var mariaSchema = []string{`
 CREATE TABLE IF NOT EXISTS ZwibblerDocs (
-	docid VARCHAR(256) PRIMARY KEY,
-	lastAccess INTEGER,
-	data LONGBLOB
-) ENGINE=InnoDB
+	id 			BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+	name 		VARCHAR(256) NOT NULL UNIQUE, 
+	autoClean	BOOLEAN NOT NULL DEFAULT 0,		
+	lastAccess 	BIGINT NOT NULL DEFAULT 0,
+	size		BIGINT NOT NULL DEFAULT 0,
+	seq			BIGINT NOT NULL DEFAULT 0
+) ENGINE=InnoDB;
+`, `
+CREATE TABLE IF NOT EXISTS ZwibblerDocParts (
+	doc 	BIGINT NOT NULL,
+	seq 	BIGINT NOT NULL,
+	data	LONGBLOB NOT NULL,
+	PRIMARY KEY (doc, seq),
+	FOREIGN KEY (doc) REFERENCES ZwibblerDocs(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
 `, `
 CREATE TABLE IF NOT EXISTS ZwibblerKeys (
-	docid VARCHAR(256) NOT NULL,
-	name VARCHAR(256) NOT NULL,
-	value TEXT,
-	version INTEGER,
-	PRIMARY KEY (docid, name),
-	FOREIGN KEY (docid) REFERENCES ZwibblerDocs (docid) ON DELETE CASCADE
-) ENGINE=InnoDB
+	doc		BIGINT NOT NULL,
+	name	VARCHAR(256) NOT NULL,
+	value	TEXT NOT NULL DEFAULT "",
+	version	BIGINT NOT NULL DEFAULT 0,
+	UNIQUE(doc, name),
+	FOREIGN KEY (doc) REFERENCES ZwibblerDocs(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
 `,
 }
 
@@ -30,5 +41,5 @@ func mariaDataSource(host string, port int, user string, password string, dbname
 }
 
 func NewMariaDb(host string, port int, user string, password string, dbname string) zwibserve.DocumentDB {
-	return NewSQLXDB(mariaDriver, mariaDataSource(host, port, user, password, dbname), mariaSchema)
+	return NewSQLXDB(mariaDriver, mariaDataSource(host, port, user, password, dbname), mariaSchema, 10)
 }

--- a/sqlxdb/mariadb.go
+++ b/sqlxdb/mariadb.go
@@ -2,7 +2,6 @@ package sqlxdb
 
 import (
 	"fmt"
-	"github.com/smhanov/zwibserve"
 )
 
 var mariaSchema = []string{`
@@ -40,6 +39,6 @@ func mariaDataSource(host string, port int, user string, password string, dbname
 	return fmt.Sprintf("%s:%s@(%s:%d)/%s", user, password, host, port, dbname)
 }
 
-func NewMariaDb(host string, port int, user string, password string, dbname string) zwibserve.DocumentDB {
-	return NewSQLXDB(mariaDriver, mariaDataSource(host, port, user, password, dbname), mariaSchema, 10)
+func NewMariaConnection(host string, port int, user string, password string, dbname string) SQLXConnection {
+	return NewSQLXConnection(mariaDriver, mariaDataSource(host, port, user, password, dbname), mariaSchema, 10)
 }

--- a/sqlxdb/mariadb.go
+++ b/sqlxdb/mariadb.go
@@ -1,0 +1,34 @@
+package sqlxdb
+
+import (
+	"fmt"
+	"github.com/smhanov/zwibserve"
+)
+
+var mariaSchema = []string{`
+CREATE TABLE IF NOT EXISTS ZwibblerDocs (
+	docid VARCHAR(256) PRIMARY KEY,
+	lastAccess INTEGER,
+	data LONGBLOB
+) ENGINE=InnoDB
+`, `
+CREATE TABLE IF NOT EXISTS ZwibblerKeys (
+	docid VARCHAR(256) NOT NULL,
+	name VARCHAR(256) NOT NULL,
+	value TEXT,
+	version INTEGER,
+	PRIMARY KEY (docid, name),
+	FOREIGN KEY (docid) REFERENCES ZwibblerDocs (docid) ON DELETE CASCADE
+) ENGINE=InnoDB
+`,
+}
+
+const mariaDriver = "mysql"
+
+func mariaDataSource(host string, port int, user string, password string, dbname string) string {
+	return fmt.Sprintf("%s:%s@(%s:%d)/%s", user, password, host, port, dbname)
+}
+
+func NewMariaDb(host string, port int, user string, password string, dbname string) zwibserve.DocumentDB {
+	return NewSQLXDB(mariaDriver, mariaDataSource(host, port, user, password, dbname), mariaSchema)
+}

--- a/sqlxdb/pgxdb.go
+++ b/sqlxdb/pgxdb.go
@@ -2,7 +2,6 @@ package sqlxdb
 
 import (
 	"fmt"
-	"github.com/smhanov/zwibserve"
 )
 
 var pgxSchema = []string{`
@@ -39,6 +38,6 @@ func pgxDataSource(host string, port int, user string, password string, dbname s
 	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", user, password, host, port, dbname)
 }
 
-func NewPgxDb(host string, port int, user string, password string, dbname string) zwibserve.DocumentDB {
-	return NewSQLXDB(pgxDriver, pgxDataSource(host, port, user, password, dbname), pgxSchema, 10)
+func NewPgxConnection(host string, port int, user string, password string, dbname string) SQLXConnection {
+	return NewSQLXConnection(pgxDriver, pgxDataSource(host, port, user, password, dbname), pgxSchema, 10)
 }

--- a/sqlxdb/pgxdb.go
+++ b/sqlxdb/pgxdb.go
@@ -1,0 +1,33 @@
+package sqlxdb
+
+import (
+	"fmt"
+	"github.com/smhanov/zwibserve"
+)
+
+var pgxSchema = []string{`
+CREATE TABLE IF NOT EXISTS ZwibblerDocs (
+	docid TEXT PRIMARY KEY, 
+	lastAccess INTEGER,
+	data BYTEA
+);
+
+CREATE TABLE IF NOT EXISTS ZwibblerKeys (
+	docID TEXT,
+	name TEXT,
+	value TEXT,
+	version INTEGER,
+	UNIQUE(docID, name),
+	FOREIGN KEY (docID) REFERENCES ZwibblerDocs(docID) ON DELETE CASCADE
+);
+`}
+
+const pgxDriver = "pgx"
+
+func pgxDataSource(host string, port int, user string, password string, dbname string) string {
+	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", user, password, host, port, dbname)
+}
+
+func NewPgxDb(host string, port int, user string, password string, dbname string) zwibserve.DocumentDB {
+	return NewSQLXDB(pgxDriver, pgxDataSource(host, port, user, password, dbname), pgxSchema)
+}

--- a/sqlxdb/pgxdb.go
+++ b/sqlxdb/pgxdb.go
@@ -7,18 +7,29 @@ import (
 
 var pgxSchema = []string{`
 CREATE TABLE IF NOT EXISTS ZwibblerDocs (
-	docid TEXT PRIMARY KEY, 
-	lastAccess INTEGER,
-	data BYTEA
+	id 			BIGSERIAL NOT NULL PRIMARY KEY,
+	name 		VARCHAR(256) NOT NULL UNIQUE, 
+	autoClean	SMALLINT NOT NULL DEFAULT 0,		
+	lastAccess 	BIGINT NOT NULL DEFAULT 0,
+	size		BIGINT NOT NULL DEFAULT 0,
+	seq			BIGINT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS ZwibblerDocParts (
+	doc 	BIGINT NOT NULL,
+	seq 	BIGINT NOT NULL,
+	data	BYTEA NOT NULL,
+	PRIMARY KEY (doc, seq),
+	FOREIGN KEY (doc) REFERENCES ZwibblerDocs(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS ZwibblerKeys (
-	docID TEXT,
-	name TEXT,
-	value TEXT,
-	version INTEGER,
-	UNIQUE(docID, name),
-	FOREIGN KEY (docID) REFERENCES ZwibblerDocs(docID) ON DELETE CASCADE
+	doc		BIGINT NOT NULL,
+	name	VARCHAR(256) NOT NULL,
+	value	TEXT,
+	version	INTEGER,
+	UNIQUE(doc, name),
+	FOREIGN KEY (doc) REFERENCES ZwibblerDocs(id) ON DELETE CASCADE
 );
 `}
 
@@ -29,5 +40,5 @@ func pgxDataSource(host string, port int, user string, password string, dbname s
 }
 
 func NewPgxDb(host string, port int, user string, password string, dbname string) zwibserve.DocumentDB {
-	return NewSQLXDB(pgxDriver, pgxDataSource(host, port, user, password, dbname), pgxSchema)
+	return NewSQLXDB(pgxDriver, pgxDataSource(host, port, user, password, dbname), pgxSchema, 10)
 }

--- a/sqlxdb/sqlitedb.go
+++ b/sqlxdb/sqlitedb.go
@@ -1,0 +1,35 @@
+package sqlxdb
+
+import (
+	"fmt"
+	"github.com/smhanov/zwibserve"
+)
+
+var sqliteSchema = []string{`
+PRAGMA foreign_keys=ON;
+
+CREATE TABLE IF NOT EXISTS ZwibblerDocs (
+	docid TEXT PRIMARY KEY, 
+	lastAccess INTEGER,
+	data BLOB
+);
+
+CREATE TABLE IF NOT EXISTS ZwibblerKeys (
+	docID TEXT,
+	name TEXT,
+	value TEXT,
+	version INTEGER,
+	UNIQUE(docID, name),
+	FOREIGN KEY (docID) REFERENCES ZwibblerDocs(docID) ON DELETE CASCADE
+);
+`}
+
+const sqliteDriver = "sqlite3"
+
+func sqliteDataSource(filename string) string {
+	return fmt.Sprintf("file:%s?_busy_timeout=5000&mode=rwc&_journal_mode=WAL&cache=shared", filename)
+}
+
+func NewSqliteDb(filename string) zwibserve.DocumentDB {
+	return NewSQLXDB(sqliteDriver, sqliteDataSource(filename), sqliteSchema)
+}

--- a/sqlxdb/sqlitedb.go
+++ b/sqlxdb/sqlitedb.go
@@ -9,18 +9,29 @@ var sqliteSchema = []string{`
 PRAGMA foreign_keys=ON;
 
 CREATE TABLE IF NOT EXISTS ZwibblerDocs (
-	docid TEXT PRIMARY KEY, 
-	lastAccess INTEGER,
-	data BLOB
+	id 			INTEGER PRIMARY KEY,
+	name 		TEXT UNIQUE, 
+	autoClean	INTEGER,		
+	lastAccess 	INTEGER,
+	size		INTEGER,
+	seq			INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS ZwibblerDocParts (
+	doc 	INTEGER NOT NULL,
+	seq 	INTEGER	NOT NULL,
+	data	BLOB,
+	PRIMARY KEY (doc, seq)
+	FOREIGN KEY (doc) REFERENCES ZwibblerDocs(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS ZwibblerKeys (
-	docID TEXT,
-	name TEXT,
-	value TEXT,
-	version INTEGER,
-	UNIQUE(docID, name),
-	FOREIGN KEY (docID) REFERENCES ZwibblerDocs(docID) ON DELETE CASCADE
+	doc		INTEGER NOT NULL,
+	name	TEXT NOT NULL,
+	value	TEXT,
+	version	INTEGER,
+	UNIQUE(doc, name),
+	FOREIGN KEY (doc) REFERENCES ZwibblerDocs(id) ON DELETE CASCADE
 );
 `}
 
@@ -31,5 +42,5 @@ func sqliteDataSource(filename string) string {
 }
 
 func NewSqliteDb(filename string) zwibserve.DocumentDB {
-	return NewSQLXDB(sqliteDriver, sqliteDataSource(filename), sqliteSchema)
+	return NewSQLXDB(sqliteDriver, sqliteDataSource(filename), sqliteSchema, 1)
 }

--- a/sqlxdb/sqlitedb.go
+++ b/sqlxdb/sqlitedb.go
@@ -2,7 +2,6 @@ package sqlxdb
 
 import (
 	"fmt"
-	"github.com/smhanov/zwibserve"
 )
 
 var sqliteSchema = []string{`
@@ -41,6 +40,6 @@ func sqliteDataSource(filename string) string {
 	return fmt.Sprintf("file:%s?_busy_timeout=5000&mode=rwc&_journal_mode=WAL&cache=shared", filename)
 }
 
-func NewSqliteDb(filename string) zwibserve.DocumentDB {
-	return NewSQLXDB(sqliteDriver, sqliteDataSource(filename), sqliteSchema, 1)
+func NewSqliteConnection(filename string) SQLXConnection {
+	return NewSQLXConnection(sqliteDriver, sqliteDataSource(filename), sqliteSchema, 1)
 }

--- a/sqlxdb/sqlxconnection.go
+++ b/sqlxdb/sqlxconnection.go
@@ -1,0 +1,77 @@
+package sqlxdb
+
+import (
+	"database/sql"
+	"github.com/jmoiron/sqlx"
+	"log"
+)
+
+type SQLXConnection interface {
+	Tx() *sqlx.Tx
+	Query(tx *sqlx.Tx, query string, args ...interface{}) *sql.Rows
+	Exec(tx *sqlx.Tx, query string, args ...interface{})
+	Commit(tx *sqlx.Tx)
+	Close(rows *sql.Rows)
+	Scan(rows *sql.Rows, fields ...interface{})
+}
+
+type sqlxConnectionImpl struct {
+	conn *sqlx.DB
+}
+
+func NewSQLXConnection(driverName, dataSourceName string, schema []string, maxOpenConnections int) SQLXConnection {
+	sqldb, err := sqlx.Connect(driverName, dataSourceName)
+
+	if err != nil {
+		log.Panic(err)
+	}
+
+	sqldb.SetMaxOpenConns(maxOpenConnections)
+
+	for i := 0; i < len(schema); i++ {
+		sqldb.MustExec(schema[i])
+	}
+
+	db := &sqlxConnectionImpl{
+		conn: sqldb,
+	}
+
+	return db
+}
+
+func (db *sqlxConnectionImpl) Tx() *sqlx.Tx {
+	return db.conn.MustBegin()
+}
+
+func (db *sqlxConnectionImpl) Query(tx *sqlx.Tx, query string, args ...interface{}) *sql.Rows {
+	rows, err := tx.Query(db.conn.Rebind(query), args...)
+	if err != nil {
+		log.Panic(err)
+	}
+	return rows
+}
+
+func (db *sqlxConnectionImpl) Exec(tx *sqlx.Tx, query string, args ...interface{}) {
+	tx.MustExec(db.conn.Rebind(query), args...)
+}
+
+func (db *sqlxConnectionImpl) Commit(tx *sqlx.Tx) {
+	err := tx.Commit()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (db *sqlxConnectionImpl) Close(rows *sql.Rows) {
+	err := rows.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (db *sqlxConnectionImpl) Scan(rows *sql.Rows, fields ...interface{}) {
+	err := rows.Scan(fields...)
+	if err != nil {
+		log.Panic(err)
+	}
+}

--- a/sqlxdb/sqlxdb.go
+++ b/sqlxdb/sqlxdb.go
@@ -1,0 +1,228 @@
+package sqlxdb
+
+import (
+	"database/sql"
+	"github.com/smhanov/zwibserve"
+	"log"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func now() int64 {
+	return time.Now().Unix()
+}
+
+// SQLXDocumentDB is a document database using SQLX. The documents are all stored in a single file database.
+type SQLXDocumentDB struct {
+	lastClean  time.Time
+	conn       *sqlx.DB
+	expiration int64
+	autoClean  bool
+}
+
+// NewSQLXDB creates a new document storage based on SQLX
+func NewSQLXDB(driverName, dataSourceName string, schema []string) zwibserve.DocumentDB {
+
+	sqldb, err := sqlx.Connect(driverName, dataSourceName)
+
+	if err != nil {
+		log.Panic(err)
+	}
+
+	sqldb.SetMaxOpenConns(1)
+
+	for i := 0; i < len(schema); i++ {
+		sqldb.MustExec(schema[i])
+	}
+
+	db := &SQLXDocumentDB{
+		conn:      sqldb,
+		autoClean: false,
+	}
+
+	db.clean()
+	return db
+}
+
+// SetExpiration ...
+func (db *SQLXDocumentDB) SetExpiration(seconds int64) {
+	db.expiration = seconds
+}
+
+func (db *SQLXDocumentDB) tx() *sqlx.Tx {
+	return db.conn.MustBegin()
+}
+
+func (db *SQLXDocumentDB) query(tx *sqlx.Tx, query string, args ...interface{}) *sql.Rows {
+	rows, err := tx.Query(db.conn.Rebind(query), args...)
+	if err != nil {
+		log.Panic(err)
+	}
+	return rows
+}
+
+func (db *SQLXDocumentDB) exec(tx *sqlx.Tx, query string, args ...interface{}) {
+	tx.MustExec(db.conn.Rebind(query), args...)
+}
+
+func (db *SQLXDocumentDB) commit(tx *sqlx.Tx) {
+	err := tx.Commit()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (db *SQLXDocumentDB) close(rows *sql.Rows) {
+	err := rows.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (db *SQLXDocumentDB) scan(rows *sql.Rows, fields ...interface{}) {
+	err := rows.Scan(fields...)
+	if err != nil {
+		log.Panic(err)
+	}
+
+}
+
+func (db *SQLXDocumentDB) clean() {
+	if db.autoClean {
+		seconds := db.expiration
+		if seconds == 0 {
+			seconds = 24 * 60 * 60
+		} else if seconds == zwibserve.NoExpiration {
+			return
+		}
+
+		now := time.Now()
+		if time.Since(db.lastClean).Minutes() < 60 {
+			return
+		}
+
+		tx := db.tx()
+		defer db.commit(tx)
+
+		db.exec(tx, "DELETE FROM ZwibblerDocs WHERE lastAccess < ?",
+			now.Unix()-seconds)
+		db.lastClean = now
+	}
+}
+
+// GetDocument ...
+func (db *SQLXDocumentDB) GetDocument(docID string, mode zwibserve.CreateMode, initialData []byte) ([]byte, bool, error) {
+	db.clean()
+
+	tx := db.tx()
+	defer db.commit(tx)
+
+	rows := db.query(tx, "SELECT data FROM ZwibblerDocs WHERE docid = ?", docID)
+	created := true
+	var doc []byte
+	if rows.Next() {
+		db.scan(rows, &doc)
+		created = false
+	}
+	db.close(rows)
+
+	if doc == nil && mode == zwibserve.NeverCreate {
+		return nil, false, zwibserve.ErrMissing
+	} else if doc != nil && mode == zwibserve.AlwaysCreate {
+		return nil, false, zwibserve.ErrExists
+	}
+
+	if doc == nil {
+		doc = initialData
+		db.exec(tx, `INSERT INTO ZwibblerDocs (docid, lastAccess, data) VALUES (?, ?, ?)`,
+			docID, now(), doc)
+	} else {
+		db.exec(tx, "UPDATE ZwibblerDocs set lastAccess = ? WHERE docid = ?", now(), docID)
+	}
+
+	return doc, created, nil
+
+}
+
+// AppendDocument ...
+func (db *SQLXDocumentDB) AppendDocument(docID string, oldLength uint64, newData []byte) (uint64, error) {
+	db.clean()
+	tx := db.tx()
+	defer db.commit(tx)
+
+	rows := db.query(tx, "SELECT data FROM ZwibblerDocs WHERE docid = ?", docID)
+
+	var doc []byte
+	if rows.Next() {
+		db.scan(rows, &doc)
+	}
+	db.close(rows)
+
+	if doc == nil {
+		return 0, zwibserve.ErrMissing
+	}
+
+	if uint64(len(doc)) != oldLength {
+		return uint64(len(doc)), zwibserve.ErrConflict
+	}
+
+	doc = append(doc, newData...)
+	db.exec(tx, "UPDATE ZwibblerDocs SET data = ? WHERE docid = ?", doc, docID)
+	db.exec(tx, "UPDATE ZwibblerDocs set lastAccess = ? WHERE docid = ?", now(), docID)
+
+	return uint64(len(doc)), nil
+}
+
+// GetDocumentKeys ...
+func (db *SQLXDocumentDB) GetDocumentKeys(docID string) ([]zwibserve.Key, error) {
+	var keys []zwibserve.Key
+
+	tx := db.tx()
+	defer db.commit(tx)
+
+	rows := db.query(tx, "SELECT name, value, version FROM ZwibblerKeys WHERE docid = ?", docID)
+
+	for rows.Next() {
+		var key zwibserve.Key
+		db.scan(rows, &key.Name, &key.Value, &key.Version)
+		keys = append(keys, key)
+	}
+	db.close(rows)
+
+	return keys, nil
+}
+
+// SetDocumentKey ...
+func (db *SQLXDocumentDB) SetDocumentKey(docID string, oldVersion int, key zwibserve.Key) error {
+	tx := db.tx()
+	defer db.commit(tx)
+
+	var dbVersion int
+	exists := false
+
+	rows := db.query(tx, "SELECT version FROM ZwibblerKeys WHERE docid = ? AND name = ?", docID, key.Name)
+	if rows.Next() {
+		exists = true
+		db.scan(rows, &dbVersion)
+	}
+	db.close(rows)
+
+	// if the key exists, and the old version does not match, then fail.
+	if exists && dbVersion != oldVersion {
+		return zwibserve.ErrConflict
+	} else if !exists && oldVersion != 0 {
+		return zwibserve.ErrConflict
+	}
+
+	// if the key exists, perform update. otherwise, perform insert.
+	if exists {
+		db.exec(tx, `UPDATE ZwibblerKeys SET value = ?, version = ? WHERE docid = ? AND name = ?`,
+			key.Value, key.Version, docID, key.Name)
+	} else {
+		db.exec(tx, `INSERT INTO ZwibblerKeys(docid, name, value, version) VALUES (?, ?, ?, ?)`,
+			docID, key.Name, key.Value, key.Version)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Added support of PostgreSQL and MariaDB through the sqlx engine. Theoretical support for any database with sqlx driver.

Reworked the database structure for better append-only behaviour (less fetches on append).
