### PR TITLE
Use sqlx for sqlite, postgres, mariadb, and mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,24 +123,24 @@ Redis must be used if using more than one server instance. To use redis, add the
     # Change this to redis
     Database=redis
 
-    # If using Redis, these are the settings.
-    # Default: localhost:6379
-    RedisServer=
-    RedisPassword=
+    # Default DbServer for Redis: localhost:6379
+    DbServer=
+    DbPassword=
+
+The DbUser field is unnecessary for Redis.
     
 #### MariaDB, PostgreSQL, and MySQL
 You can use another relational database for the collaboration server. To use MariaDB, PostgreSQL, or MySQL, change the Database config:
 
-    # Can be sqlite, postgres, mysql, mariadb, or redis or redis-cluster
-    Database=sqlite
+    Database=mariadb
 
 Then insert the DB settings:
 
-    # If using another relational database, these are the settings.
-    DbPort=
-    DbHost=
-    DbUser=
+    # Default DbServer for MariaDB and MySQL: localhost:3306
+    # Default DbServer for Redis: localhost:6379
+    DbServer=
     DbPassword=
+    DbUser=
 
 ## Advanced options
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The data is stored in an SQLITE database in /var/lib/zwibbler/zwibbler.db. The c
 #### Redis
 Redis must be used if using more than one server instance. To use redis, add these lines to the zwibbler.conf file:
 
-    # Can be sqlite or redis
+    # Change this to redis
     Database=redis
 
     # If using Redis, these are the settings.
@@ -128,6 +128,20 @@ Redis must be used if using more than one server instance. To use redis, add the
     RedisServer=
     RedisPassword=
     
+#### MariaDB, PostgreSQL, and MySQL
+You can use another relational database for the collaboration server. To use MariaDB, PostgreSQL, or MySQL, change the Database config:
+
+    # Can be sqlite, postgres, mysql, mariadb, or redis or redis-cluster
+    Database=sqlite
+
+Then insert the DB settings:
+
+    # If using another relational database, these are the settings.
+    DbPort=
+    DbHost=
+    DbUser=
+    DbPassword=
+
 ## Advanced options
 
 ### Document lifetime

--- a/mariadb.go
+++ b/mariadb.go
@@ -7,32 +7,32 @@ import (
 
 const mariadbSchema = `
 CREATE TABLE IF NOT EXISTS ZwibblerDocs (
-    docID VARCHAR(255) PRIMARY KEY,
+    docID TEXT PRIMARY KEY,
     lastAccess BIGINT,
     data LONGBLOB
 );
 
 CREATE TABLE IF NOT EXISTS ZwibblerKeys (
-    docID VARCHAR(255),
-    name VARCHAR(255),
-    value VARCHAR(255),
+    docID TEXT,
+    name TEXT,
+    value MEDIUMTEXT,
     version INT,
     UNIQUE(docID, name),
     FOREIGN KEY (docID) REFERENCES ZwibblerDocs(docid) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS ZwibblerTokens (
-    tokenID VARCHAR(255) UNIQUE,
-    docID VARCHAR(255),
-    userID VARCHAR(255),
-    permissions VARCHAR(255),
+    tokenID TEXT UNIQUE,
+    docID TEXT,
+    userID TEXT,
+    permissions TEXT,
     expiration BIGINT
 );
 
 CREATE INDEX IF NOT EXISTS ZwibblerTokenUserIndex ON ZwibblerTokens(userID);
 `
 
-func NewMariaDBConnection(port int, host, user, password, dbname string) DocumentDB {
-	mariaInfo := fmt.Sprintf("%s:%s@(%s:%d)/%s?multiStatements=true", user, password, host, port, dbname)
+func NewMariaDBConnection(server, user, password, dbname string) DocumentDB {
+	mariaInfo := fmt.Sprintf("%s:%s@(%s)/%s?multiStatements=true", user, password, server, dbname)
 	return NewSQLXConnection("mysql", mariaInfo, mariadbSchema, 1, false)
 }

--- a/mariadb.go
+++ b/mariadb.go
@@ -1,0 +1,38 @@
+package zwibserve
+
+import (
+	"fmt"
+	_ "github.com/go-sql-driver/mysql" // include mysql driver
+)
+
+const mariadbSchema = `
+CREATE TABLE IF NOT EXISTS ZwibblerDocs (
+    docID VARCHAR(255) PRIMARY KEY,
+    lastAccess BIGINT,
+    data LONGBLOB
+);
+
+CREATE TABLE IF NOT EXISTS ZwibblerKeys (
+    docID VARCHAR(255),
+    name VARCHAR(255),
+    value VARCHAR(255),
+    version INT,
+    UNIQUE(docID, name),
+    FOREIGN KEY (docID) REFERENCES ZwibblerDocs(docid) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS ZwibblerTokens (
+    tokenID VARCHAR(255) UNIQUE,
+    docID VARCHAR(255),
+    userID VARCHAR(255),
+    permissions VARCHAR(255),
+    expiration BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS ZwibblerTokenUserIndex ON ZwibblerTokens(userID);
+`
+
+func NewMariaDBConnection(port int, host, user, password, dbname string) DocumentDB {
+	mariaInfo := fmt.Sprintf("%s:%s@(%s:%d)/%s?multiStatements=true", user, password, host, port, dbname)
+	return NewSQLXConnection("mysql", mariaInfo, mariadbSchema, 1, false)
+}

--- a/mysql.go
+++ b/mysql.go
@@ -1,0 +1,13 @@
+package zwibserve
+
+import (
+	"fmt"
+	_ "github.com/go-sql-driver/mysql" // include mysql driver
+)
+
+const mysqlSchema = mariadbSchema // Reuse MariaDB schema
+
+func NewMySQLConnection(port int, host, user, password, dbname string) DocumentDB {
+	mysqlInfo := fmt.Sprintf("%s:%s@(%s:%d)/%s", user, password, host, port, dbname)
+	return NewSQLXConnection("mysql", mysqlInfo, mysqlSchema, 1, false)
+}

--- a/mysql.go
+++ b/mysql.go
@@ -7,7 +7,7 @@ import (
 
 const mysqlSchema = mariadbSchema // Reuse MariaDB schema
 
-func NewMySQLConnection(port int, host, user, password, dbname string) DocumentDB {
-	mysqlInfo := fmt.Sprintf("%s:%s@(%s:%d)/%s", user, password, host, port, dbname)
+func NewMySQLConnection(server, user, password, dbname string) DocumentDB {
+	mysqlInfo := fmt.Sprintf("%s:%s@(%s)/%s", user, password, server, dbname)
 	return NewSQLXConnection("mysql", mysqlInfo, mysqlSchema, 1, false)
 }

--- a/postgresql.go
+++ b/postgresql.go
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS ZwibblerDocs (
 CREATE TABLE IF NOT EXISTS ZwibblerKeys (
 	docID TEXT,
 	name TEXT,
-	value MEDIUMTEXT,
+	value TEXT,
 	version INT,
 	UNIQUE(docID, name),
 	FOREIGN KEY (docID) REFERENCES ZwibblerDocs(docID) ON DELETE CASCADE

--- a/postgresql.go
+++ b/postgresql.go
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS ZwibblerDocs (
 CREATE TABLE IF NOT EXISTS ZwibblerKeys (
 	docID TEXT,
 	name TEXT,
-	value TEXT,
+	value MEDIUMTEXT,
 	version INT,
 	UNIQUE(docID, name),
 	FOREIGN KEY (docID) REFERENCES ZwibblerDocs(docID) ON DELETE CASCADE
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS ZwibblerTokens (
 CREATE INDEX IF NOT EXISTS ZwibblerTokenUserIndex ON ZwibblerTokens(userID);
 `
 
-func NewPostgreSQLConnection(port int, host, user, password, dbname string) DocumentDB {
-	psqlInfo := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", user, password, host, port, dbname)
+func NewPostgreSQLConnection(server, user, password, dbname string) DocumentDB {
+	psqlInfo := fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable", user, password, server, dbname)
 	return NewSQLXConnection("postgres", psqlInfo, postgresqlSchema, 1, true)
 }

--- a/postgresql.go
+++ b/postgresql.go
@@ -2,23 +2,21 @@ package zwibserve
 
 import (
 	"fmt"
-	_ "github.com/mattn/go-sqlite3" // include sqlite3
+	_ "github.com/lib/pq" // include postgresql driver
 )
 
-const sqliteSchema = `
-PRAGMA foreign_keys=ON;
-
+const postgresqlSchema = `
 CREATE TABLE IF NOT EXISTS ZwibblerDocs (
-	docid TEXT PRIMARY KEY, 
-	lastAccess INTEGER,
-	data BLOB
+	docid TEXT PRIMARY KEY,
+	lastAccess BIGINT,
+	data BYTEA
 );
 
 CREATE TABLE IF NOT EXISTS ZwibblerKeys (
 	docID TEXT,
 	name TEXT,
 	value TEXT,
-	version NUMBER,
+	version INT,
 	UNIQUE(docID, name),
 	FOREIGN KEY (docID) REFERENCES ZwibblerDocs(docID) ON DELETE CASCADE
 );
@@ -28,13 +26,13 @@ CREATE TABLE IF NOT EXISTS ZwibblerTokens (
 	docID TEXT,
 	userID TEXT,
 	permissions TEXT,
-	expiration INTEGER
+	expiration BIGINT
 );
 
 CREATE INDEX IF NOT EXISTS ZwibblerTokenUserIndex ON ZwibblerTokens(userID);
 `
 
-// NewSQLITEDB creates a new document storage based on SQLITE
-func NewSQLITEDB(filename string) DocumentDB {
-	return NewSQLXConnection("sqlite3", fmt.Sprintf("file:%s?_busy_timeout=5000&mode=rwc&_journal_mode=WAL&cache=shared", filename), sqliteSchema, 1, false)
+func NewPostgreSQLConnection(port int, host, user, password, dbname string) DocumentDB {
+	psqlInfo := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable", user, password, host, port, dbname)
+	return NewSQLXConnection("postgres", psqlInfo, postgresqlSchema, 1, true)
 }

--- a/sqlitedb.go
+++ b/sqlitedb.go
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS ZwibblerDocs (
 CREATE TABLE IF NOT EXISTS ZwibblerKeys (
 	docID TEXT,
 	name TEXT,
-	value TEXT,
+	value MEDIUMTEXT,
 	version NUMBER,
 	UNIQUE(docID, name),
 	FOREIGN KEY (docID) REFERENCES ZwibblerDocs(docID) ON DELETE CASCADE

--- a/sqlitedb.go
+++ b/sqlitedb.go
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS ZwibblerDocs (
 CREATE TABLE IF NOT EXISTS ZwibblerKeys (
 	docID TEXT,
 	name TEXT,
-	value MEDIUMTEXT,
+	value TEXT,
 	version NUMBER,
 	UNIQUE(docID, name),
 	FOREIGN KEY (docID) REFERENCES ZwibblerDocs(docID) ON DELETE CASCADE

--- a/sqlxdb.go
+++ b/sqlxdb.go
@@ -1,0 +1,285 @@
+package zwibserve
+
+import (
+	"log"
+	"strings"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type SQLxDocumentDB struct {
+	lastClean  time.Time
+	conn       *sqlx.DB
+	expiration int64
+}
+
+var shouldRebind = false
+
+func rebindQuery(query string) string {
+	if shouldRebind {
+		return sqlx.Rebind(sqlx.DOLLAR, query)
+	}
+	return query
+}
+
+func NewSQLXConnection(driverName, dataSourceName string, schema string, maxOpenConnections int, rebind bool) DocumentDB {
+	shouldRebind = rebind
+	sqldb, err := sqlx.Connect(driverName, dataSourceName)
+
+	if err != nil {
+		log.Panic(err)
+	}
+
+	sqldb.SetMaxOpenConns(maxOpenConnections)
+
+	sqldb.MustExec(schema)
+
+	db := &SQLxDocumentDB{
+		conn: sqldb,
+	}
+
+	db.clean()
+	return db
+}
+
+// SetExpiration ...
+func (db *SQLxDocumentDB) SetExpiration(seconds int64) {
+	log.Printf("SetExpiration")
+	db.expiration = seconds
+}
+
+func (db *SQLxDocumentDB) CheckHealth() error {
+	log.Printf("CheckHealth")
+	tx := db.conn.MustBegin()
+	return tx.Commit()
+}
+
+func (db *SQLxDocumentDB) clean() {
+	log.Printf("clean")
+	seconds := db.expiration
+	if seconds == 0 || seconds == NoExpiration {
+		return
+	}
+
+	now := time.Now()
+	if time.Since(db.lastClean).Minutes() < 60 {
+		return
+	}
+
+	db.conn.MustExec(rebindQuery("DELETE FROM ZwibblerDocs WHERE lastAccess < ?"), now.Unix()-seconds)
+	db.conn.MustExec(rebindQuery("DELETE FROM ZwibblerTokens WHERE expiration < ?"), now.Unix())
+	db.lastClean = now
+}
+
+// GetDocument ...
+func (db *SQLxDocumentDB) GetDocument(docID string, mode CreateMode, initialData []byte) ([]byte, bool, error) {
+	log.Printf("GetDocument")
+	db.clean()
+
+	tx := db.conn.MustBegin()
+	defer tx.Commit()
+
+	rows, err := tx.Query(rebindQuery("SELECT data FROM ZwibblerDocs WHERE docid=?"), docID)
+	if err != nil {
+		tx.Rollback()
+		log.Panic(err)
+	}
+	defer rows.Close()
+
+	created := true
+	var doc []byte
+	if rows.Next() {
+		err = rows.Scan(&doc)
+		if err != nil {
+			log.Panic(err)
+		}
+		created = false
+	}
+	rows.Close()
+
+	if doc == nil && mode == NeverCreate {
+		return nil, false, ErrMissing
+	} else if doc != nil && mode == AlwaysCreate {
+		return nil, false, ErrExists
+	}
+
+	if doc == nil {
+		doc = initialData
+		tx.MustExec(rebindQuery("INSERT INTO ZwibblerDocs (docid, lastAccess, data) VALUES (?, ?, ?)"), docID, time.Now().Unix(), doc)
+	} else {
+		tx.MustExec(rebindQuery("UPDATE ZwibblerDocs set lastAccess=? WHERE docid=?"), time.Now().Unix(), docID)
+	}
+
+	return doc, created, nil
+
+}
+
+// AppendDocument ...
+func (db *SQLxDocumentDB) AppendDocument(docID string, oldLength uint64, newData []byte) (uint64, error) {
+	log.Printf("AppendDocument")
+	db.clean()
+	tx := db.conn.MustBegin()
+	defer tx.Commit()
+
+	rows, err := tx.Query(rebindQuery("SELECT data FROM ZwibblerDocs WHERE docid=?"), docID)
+	if err != nil {
+		log.Panic(err)
+	}
+	defer rows.Close()
+
+	var doc []byte
+	if rows.Next() {
+		err = rows.Scan(&doc)
+		if err != nil {
+			log.Panic(err)
+		}
+	}
+	rows.Close()
+
+	if doc == nil {
+		return 0, ErrMissing
+	}
+
+	if uint64(len(doc)) != oldLength {
+		return uint64(len(doc)), ErrConflict
+	}
+
+	doc = append(doc, newData...)
+	tx.MustExec(rebindQuery("UPDATE ZwibblerDocs SET data=? WHERE docid=?"), doc, docID)
+	tx.MustExec(rebindQuery("UPDATE ZwibblerDocs SET lastAccess=? WHERE docid=?"), time.Now().Unix(), docID)
+
+	return uint64(len(doc)), nil
+}
+
+// GetDocumentKeys ...
+func (db *SQLxDocumentDB) GetDocumentKeys(docID string) ([]Key, error) {
+	log.Printf("GetDocumentKeys")
+	var keys []Key
+
+	tx := db.conn.MustBegin()
+	defer tx.Commit()
+
+	rows, err := tx.Query(rebindQuery("SELECT name, value, version FROM ZwibblerKeys WHERE docid=?"), docID)
+	if err != nil {
+		log.Panic(err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var key Key
+		err = rows.Scan(&key.Name, &key.Value, &key.Version)
+		if err != nil {
+			log.Panic(err)
+		}
+		keys = append(keys, key)
+	}
+
+	return keys, nil
+}
+
+// SetDocumentKey ...
+func (db *SQLxDocumentDB) SetDocumentKey(docID string, oldVersion int, key Key) error {
+	tx := db.conn.MustBegin()
+	defer tx.Commit()
+
+	var dbVersion int
+	exists := false
+
+	rows, err := tx.Query(rebindQuery("SELECT version FROM ZwibblerKeys WHERE docid=? AND name=?"), docID, key.Name)
+	if err != nil {
+		log.Panic(err)
+	}
+	defer rows.Close()
+	if rows.Next() {
+		exists = true
+		err = rows.Scan(&dbVersion)
+		if err != nil {
+			log.Panic(err)
+		}
+	}
+	rows.Close()
+
+	// if the key exists, and the old version does not match, then fail.
+	if exists && dbVersion != oldVersion {
+		return ErrConflict
+	} else if !exists && oldVersion != 0 {
+		return ErrConflict
+	}
+
+	// if the key exists, perform update. otherwise, perform insert.
+	if exists {
+		tx.MustExec(rebindQuery("UPDATE ZwibblerKeys SET value=?, version=? WHERE docID=? AND name=?"),
+			key.Value, key.Version, docID, key.Name)
+	} else {
+		tx.MustExec(rebindQuery( "INSERT INTO ZwibblerKeys(docID, name, value, version) VALUES (?, ?, ?, ?)"),
+			docID, key.Name, key.Value, key.Version)
+	}
+
+	return nil
+}
+
+func (db *SQLxDocumentDB) DeleteDocument(docID string) error {
+	db.conn.MustExec(rebindQuery("DELETE FROM ZwibblerDocs WHERE docID=?"), docID)
+	return nil
+}
+
+// AddToken ...
+func (db *SQLxDocumentDB) AddToken(tokenID, docID, userID, permissions string, expirationSeconds int64, contents []byte) error {
+	tx := db.conn.MustBegin()
+	defer tx.Commit()
+
+	// check if doc exists
+	if len(contents) > 0 {
+		rows, err := tx.Query(rebindQuery("SELECT data FROM ZwibblerDocs WHERE docid=?"), docID)
+		if err != nil {
+			log.Panic(err)
+		}
+		defer rows.Close()
+		if rows.Next() {
+			return ErrConflict
+		}
+
+		tx.MustExec(rebindQuery("INSERT INTO ZwibblerDocs (docid, lastAccess, data) VALUES (?, ?, ?)"),
+			docID, time.Now().Unix(), contents)
+	}
+
+	_, err := tx.Exec(rebindQuery("INSERT INTO ZwibblerTokens(tokenID, docID, userID, permissions, expiration) VALUES (?, ?, ?, ?, ?)"),
+		tokenID, docID, userID, permissions, expirationSeconds)
+
+	if err != nil {
+		tx.Rollback()
+		if strings.Contains(err.Error(), "UNIQUE") {
+			err = ErrExists
+		}
+	}
+
+	return err
+}
+
+func (db *SQLxDocumentDB) GetToken(token string) (docID, userID, permissions string, err error) {
+	tx := db.conn.MustBegin()
+	defer tx.Commit()
+	now := time.Now().Unix()
+	rows, err := tx.Query(rebindQuery("SELECT docID, userID, permissions FROM ZwibblerTokens WHERE tokenID=? AND expiration > ?"),
+		token, now)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	if rows.Next() {
+		err = rows.Scan(&docID, &userID, &permissions)
+	} else {
+		err = ErrMissing
+	}
+
+	return
+}
+
+func (db *SQLxDocumentDB) UpdateUser(userID, permissions string) error {
+	tx := db.conn.MustBegin()
+	defer tx.Commit()
+	tx.MustExec(rebindQuery("UPDATE ZwibblerTokens SET permissions=? WHERE userID=?"), userID, permissions)
+	return nil
+}

--- a/sqlxdb.go
+++ b/sqlxdb.go
@@ -96,7 +96,7 @@ func (db *SQLxDocumentDB) GetDocument(docID string, mode CreateMode, initialData
 		}
 		created = false
 	}
-	rows.Close()
+	rows.Close() // Necessary for postgresql
 
 	if doc == nil && mode == NeverCreate {
 		return nil, false, ErrMissing
@@ -135,7 +135,7 @@ func (db *SQLxDocumentDB) AppendDocument(docID string, oldLength uint64, newData
 			log.Panic(err)
 		}
 	}
-	rows.Close()
+	rows.Close() // Necessary for postgresql
 
 	if doc == nil {
 		return 0, ErrMissing
@@ -198,7 +198,7 @@ func (db *SQLxDocumentDB) SetDocumentKey(docID string, oldVersion int, key Key) 
 			log.Panic(err)
 		}
 	}
-	rows.Close()
+	rows.Close() // Necessary for postgresql
 
 	// if the key exists, and the old version does not match, then fail.
 	if exists && dbVersion != oldVersion {


### PR DESCRIPTION
Supports all databases compatible with SQLx, with the ability to use all current functions.